### PR TITLE
Feat/copy address component

### DIFF
--- a/apps/web/components/wallet/copy-address-button.tsx
+++ b/apps/web/components/wallet/copy-address-button.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { isValidStellarAddress } from "@/lib/stellar";
+
+interface CopyAddressButtonProps {
+  address: string;
+  className?: string;
+}
+
+function shorten(address: string): string {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export function CopyAddressButton({ address, className }: CopyAddressButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const valid = useMemo(() => isValidStellarAddress(address), [address]);
+
+  const copy = async () => {
+    if (!valid) return;
+    await navigator.clipboard.writeText(address);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  if (!valid) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => void copy()}
+      aria-label={`Copy wallet address ${address}`}
+      className={
+        className ??
+        "inline-flex items-center gap-1 rounded-xl border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-300 transition-opacity duration-200 hover:opacity-80"
+      }
+    >
+      <span>{shorten(address)}</span>
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-indigo-300" />
+      ) : (
+        <Copy className="h-3.5 w-3.5 text-zinc-400" />
+      )}
+    </button>
+  );
+}

--- a/apps/web/components/wallet/transaction-pending-notification.tsx
+++ b/apps/web/components/wallet/transaction-pending-notification.tsx
@@ -2,15 +2,12 @@
 
 import { LoaderCircle, TriangleAlert, Unplug } from "lucide-react";
 import { useWalletSession } from "@/hooks/use-wallet-session";
+import { CopyAddressButton } from "@/components/wallet/copy-address-button";
 
 interface TransactionPendingNotificationProps {
   isPending: boolean;
   pendingText?: string;
   txHash?: string | null;
-}
-
-function shortAddress(address: string): string {
-  return `${address.slice(0, 6)}...${address.slice(-6)}`;
 }
 
 export function TransactionPendingNotification({
@@ -42,9 +39,10 @@ export function TransactionPendingNotification({
           </p>
           <p className="text-sm text-zinc-300" aria-live="polite">
             {isConnected && address
-              ? `Connected as ${shortAddress(address)}`
+              ? "Connected wallet"
               : "No wallet connected"}
           </p>
+          {isConnected && address ? <CopyAddressButton address={address} /> : null}
           <p className="text-xs text-zinc-400">App network: {appNetwork}</p>
           {walletNetwork ? (
             <p className="text-xs text-zinc-400">Wallet network: {walletNetwork}</p>


### PR DESCRIPTION
## Summary

Adds a reusable "Copy Address" utility component for Stellar wallets.

## Changes

* Created `copy-address-button` component
* Validates Stellar address before copying
* Copies full address to clipboard with visual feedback
* Displays shortened address in UI
* Integrated into navbar (desktop + mobile) and transaction panel
* Added ARIA labels for accessibility

## Notes

* Only public address is used; no sensitive data involved
* Designed with Zinc-900 base and Indigo accents for consistency

Closes #116