### PR TITLE
feat(wallet): refactor address truncation using shortenAddress utility

### DIFF
--- a/apps/web/components/wallet/connect-wallet-button.tsx
+++ b/apps/web/components/wallet/connect-wallet-button.tsx
@@ -5,6 +5,7 @@ import { useWalletSession } from "@/hooks/use-wallet-session";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { WalletErrorBanner } from "./wallet-error-display";
+import { shortenAddress } from "@/lib/format";
 
 interface ConnectWalletButtonProps {
   className?: string;
@@ -65,7 +66,7 @@ export function ConnectWalletButton({ className }: ConnectWalletButtonProps) {
   }
 
   if (isConnected && address) {
-    const truncated = `${address.slice(0, 4)}…${address.slice(-4)}`;
+    const truncated = shortenAddress(address, 4, 4);
 
     return (
       <div className={cn("flex flex-col items-end gap-1 responsive-gap", className)}>


### PR DESCRIPTION
Closes #104

---

I refactored wallet address truncation by replacing manual logic with the shortenAddress utility for cleaner, reusable, and more consistent address formatting across the wallet feature.