### PR TITLE
 Frontend: Implement "Submit Bid" Modal

### DIFF
--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -13,6 +13,8 @@ import {
   Wallet,
 } from "lucide-react";
 import { BidList } from "@/components/jobs/bid-list";
+import { SubmitBidErrorBoundary } from "@/components/jobs/submit-bid-error-boundary";
+import { SubmitBidModal } from "@/components/jobs/submit-bid-modal";
 import { SiteShell } from "@/components/site-shell";
 import { Stars } from "@/components/stars";
 import { JobDetailsSkeleton } from "@/components/ui/skeleton";
@@ -32,7 +34,6 @@ export default function JobDetailsPage() {
   const router = useRouter();
   const workspace = useLiveJobWorkspace(id);
   const [viewerAddress, setViewerAddress] = useState<string | null>(null);
-  const [proposal, setProposal] = useState("");
   const [deliverableLabel, setDeliverableLabel] = useState("");
   const [deliverableLink, setDeliverableLink] = useState("");
   const [deliverableFile, setDeliverableFile] = useState<File | null>(null);
@@ -47,26 +48,6 @@ export default function JobDetailsPage() {
     const connected = await connectWallet();
     setViewerAddress(connected);
     return connected;
-  }
-
-  async function handleBid(event: React.FormEvent) {
-    event.preventDefault();
-    setBusyAction("bid");
-
-    try {
-      const freelancerAddress =
-        (await getConnectedWalletAddress()) ?? "GD...FREELANCER";
-      await api.bids.create(id, {
-        freelancer_address: freelancerAddress,
-        proposal,
-      });
-      setProposal("");
-      await workspace.refresh();
-    } catch {
-      alert("Failed to submit bid");
-    } finally {
-      setBusyAction(null);
-    }
   }
 
   async function handleAcceptBid(bidId: string) {
@@ -292,31 +273,25 @@ export default function JobDetailsPage() {
 
           {job.status === "open" ? (
             <div className="grid gap-6 xl:grid-cols-[1fr_0.95fr]">
-              <section className="rounded-[2rem] border border-slate-200 bg-white/85 p-6 shadow-[0_20px_60px_-48px_rgba(15,23,42,0.45)]">
-                <h2 className="text-xl font-semibold text-slate-950">
+              <section className="rounded-[2rem] border border-zinc-700/60 bg-zinc-950/90 p-6 shadow-[0_20px_60px_-48px_rgba(0,0,0,0.8)]">
+                <h2 className="text-xl font-semibold text-zinc-50">
                   Submit a Proposal
                 </h2>
-                <p className="mt-2 text-sm leading-6 text-slate-600">
+                <p className="mt-2 text-sm leading-6 text-zinc-300">
                   Pitch your approach, timing, and why your previous work maps cleanly to this brief.
                 </p>
-                <form onSubmit={handleBid} className="mt-5 space-y-4">
-                  <textarea
-                    value={proposal}
-                    onChange={(event) => setProposal(event.target.value)}
-                    className="min-h-[160px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-slate-950 outline-none transition focus:border-amber-400"
-                    placeholder="Tell the client why you're a fit..."
-                    required
-                    id="bid-proposal"
-                  />
-                  <button
-                    type="submit"
-                    disabled={busyAction === "bid"}
-                    className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:opacity-50"
-                    id="submit-bid"
-                  >
-                    {busyAction === "bid" ? "Submitting..." : "Submit Bid"}
-                  </button>
-                </form>
+                <div className="mt-5">
+                  <SubmitBidErrorBoundary>
+                    <SubmitBidModal
+                      jobId={id}
+                      disabled={busyAction !== null}
+                      onSubmitted={workspace.refresh}
+                      resolveFreelancerAddress={async () =>
+                        (await getConnectedWalletAddress()) ?? "GD...FREELANCER"
+                      }
+                    />
+                  </SubmitBidErrorBoundary>
+                </div>
               </section>
 
               <section className="rounded-[2rem] border border-slate-200 bg-white/85 p-6 shadow-[0_20px_60px_-48px_rgba(15,23,42,0.45)]">

--- a/apps/web/components/jobs/__tests__/submit-bid-modal.test.tsx
+++ b/apps/web/components/jobs/__tests__/submit-bid-modal.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { SubmitBidModal, submitBidSchema } from "../submit-bid-modal";
+
+const createBidMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    bids: {
+      create: (...args: unknown[]) => createBidMock(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+function renderModal() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const onSubmitted = vi.fn().mockResolvedValue(undefined);
+  const resolveFreelancerAddress = vi.fn().mockResolvedValue("GABC123");
+
+  render(
+    <QueryClientProvider client={client}>
+      <SubmitBidModal
+        jobId="job-123"
+        onSubmitted={onSubmitted}
+        resolveFreelancerAddress={resolveFreelancerAddress}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { onSubmitted, resolveFreelancerAddress };
+}
+
+describe("submitBidSchema", () => {
+  it("rejects proposal shorter than 24 chars", () => {
+    const parsed = submitBidSchema.safeParse({ proposal: "too short" });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts a valid proposal", () => {
+    const parsed = submitBidSchema.safeParse({
+      proposal: "I will ship this in milestones with weekly check-ins.",
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe("SubmitBidModal", () => {
+  beforeEach(() => {
+    createBidMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+  });
+
+  it("shows validation feedback and disables submission until valid", () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Bid" }));
+
+    const textarea = screen.getByLabelText("Proposal");
+    fireEvent.change(textarea, { target: { value: "short" } });
+
+    expect(screen.getByText(/at least 24 characters/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send Bid" })).toBeDisabled();
+  });
+
+  it("submits bid and closes modal on success", async () => {
+    createBidMock.mockResolvedValue({ id: "bid-1" });
+    const { onSubmitted, resolveFreelancerAddress } = renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Bid" }));
+    fireEvent.change(screen.getByLabelText("Proposal"), {
+      target: {
+        value:
+          "I can deliver this in two milestones with contract-safe updates and daily standups.",
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send Bid" }));
+
+    await waitFor(() => {
+      expect(resolveFreelancerAddress).toHaveBeenCalledTimes(1);
+      expect(createBidMock).toHaveBeenCalledWith("job-123", {
+        freelancer_address: "GABC123",
+        proposal:
+          "I can deliver this in two milestones with contract-safe updates and daily standups.",
+      });
+      expect(onSubmitted).toHaveBeenCalledTimes(1);
+      expect(toastSuccessMock).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows API failure message", async () => {
+    createBidMock.mockRejectedValue(new Error("backend failed"));
+    renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit Bid" }));
+    fireEvent.change(screen.getByLabelText("Proposal"), {
+      target: {
+        value: "This is a complete proposal that satisfies validation constraints.",
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send Bid" }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "backend failed" }),
+      );
+    });
+  });
+});

--- a/apps/web/components/jobs/submit-bid-error-boundary.tsx
+++ b/apps/web/components/jobs/submit-bid-error-boundary.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+
+interface SubmitBidErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class SubmitBidErrorBoundary extends React.Component<
+  React.PropsWithChildren,
+  SubmitBidErrorBoundaryState
+> {
+  state: SubmitBidErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): SubmitBidErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-[1.5rem] border border-amber-500/40 bg-zinc-950/85 p-5 text-amber-200">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em]">Bid action unavailable</p>
+          <p className="mt-2 text-sm text-zinc-300">
+            The bid form failed to load. Refresh and try again.
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/web/components/jobs/submit-bid-modal.tsx
+++ b/apps/web/components/jobs/submit-bid-modal.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { AlertCircle, LoaderCircle, X } from "lucide-react";
+import { z } from "zod";
+import { api } from "@/lib/api";
+import { toast } from "@/lib/toast";
+
+const submitBidSchema = z.object({
+  proposal: z
+    .string()
+    .trim()
+    .min(24, "Proposal must be at least 24 characters.")
+    .max(2000, "Proposal must be 2,000 characters or fewer."),
+});
+
+interface SubmitBidModalProps {
+  jobId: string;
+  disabled?: boolean;
+  onSubmitted: () => Promise<void>;
+  resolveFreelancerAddress: () => Promise<string>;
+}
+
+export function SubmitBidModal({
+  jobId,
+  disabled = false,
+  onSubmitted,
+  resolveFreelancerAddress,
+}: SubmitBidModalProps) {
+  const [open, setOpen] = useState(false);
+  const [proposal, setProposal] = useState("");
+  const validation = useMemo(
+    () => submitBidSchema.safeParse({ proposal }),
+    [proposal],
+  );
+
+  const proposalError =
+    proposal.length === 0
+      ? ""
+      : validation.success
+        ? ""
+        : validation.error.flatten().fieldErrors.proposal?.[0] ?? "";
+
+  const mutation = useMutation({
+    mutationFn: async (payload: { proposal: string }) => {
+      const freelancerAddress = await resolveFreelancerAddress();
+      return api.bids.create(jobId, {
+        freelancer_address: freelancerAddress,
+        proposal: payload.proposal,
+      });
+    },
+    onSuccess: async () => {
+      toast.success({
+        title: "Bid submitted",
+        description: "Your proposal was sent to the client for review.",
+      });
+      setProposal("");
+      setOpen(false);
+      await onSubmitted();
+    },
+    onError: (error) => {
+      toast.error({
+        title: "Could not submit bid",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Please try again in a moment.",
+      });
+    },
+  });
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const parsed = submitBidSchema.safeParse({ proposal });
+    if (!parsed.success) {
+      return;
+    }
+
+    mutation.mutate({ proposal: parsed.data.proposal });
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center justify-center rounded-xl bg-emerald-500 px-6 py-3 text-sm font-semibold text-zinc-950 transition duration-150 hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        Submit Bid
+      </button>
+
+      {open ? (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-zinc-950/75 p-4 backdrop-blur-sm sm:items-center"
+          role="presentation"
+          onClick={() => !mutation.isPending && setOpen(false)}
+        >
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="submit-bid-title"
+            aria-describedby="submit-bid-description"
+            className="w-full max-w-xl rounded-xl border border-white/15 bg-zinc-900/85 p-6 shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-400">
+                  Open Opportunity
+                </p>
+                <h3 id="submit-bid-title" className="mt-2 text-2xl font-semibold text-zinc-50">
+                  Submit your bid
+                </h3>
+                <p id="submit-bid-description" className="mt-2 text-sm text-zinc-300">
+                  Share your execution plan, delivery confidence, and what makes you the best fit.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                disabled={mutation.isPending}
+                className="rounded-lg border border-zinc-700 p-2 text-zinc-300 transition duration-150 hover:border-zinc-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-200 active:translate-y-px disabled:opacity-50"
+                aria-label="Close submit bid modal"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+              <label htmlFor="bid-proposal" className="block text-sm font-medium text-zinc-100">
+                Proposal
+              </label>
+              <textarea
+                id="bid-proposal"
+                value={proposal}
+                onChange={(event) => setProposal(event.target.value)}
+                className="min-h-[168px] w-full rounded-xl border border-zinc-700 bg-zinc-950/80 px-4 py-3 text-sm text-zinc-100 outline-none transition duration-150 placeholder:text-zinc-500 hover:border-zinc-500 focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/35"
+                placeholder="Describe your process, delivery checkpoints, and relevant Web3 work."
+                aria-invalid={Boolean(proposalError)}
+                aria-describedby={proposalError ? "bid-proposal-error" : undefined}
+                required
+              />
+              <div className="flex items-center justify-between text-xs text-zinc-400">
+                <span>{proposal.trim().length}/2000</span>
+                {proposalError ? (
+                  <span
+                    id="bid-proposal-error"
+                    className="inline-flex items-center gap-1 font-medium text-amber-400"
+                  >
+                    <AlertCircle className="h-3.5 w-3.5" />
+                    {proposalError}
+                  </span>
+                ) : (
+                  <span className="text-emerald-400">Looks good</span>
+                )}
+              </div>
+
+              <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  disabled={mutation.isPending}
+                  className="rounded-xl border border-zinc-600 px-4 py-2 text-sm font-semibold text-zinc-200 transition duration-150 hover:border-zinc-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-200 active:translate-y-px disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={mutation.isPending || !validation.success}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-zinc-950 transition duration-150 hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {mutation.isPending ? (
+                    <>
+                      <LoaderCircle className="h-4 w-4 animate-spin" />
+                      Submitting...
+                    </>
+                  ) : (
+                    "Send Bid"
+                  )}
+                </button>
+              </div>
+            </form>
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+export { submitBidSchema };


### PR DESCRIPTION
close #133 

Description
Added a new SubmitBidModal component that uses zod for submitBidSchema validation and useMutation from TanStack Query to submit bids with loading/error/success toast feedback (apps/web/components/jobs/submit-bid-modal.tsx).
Added a SubmitBidErrorBoundary to prevent bid UI rendering failures from crashing the job page (apps/web/components/jobs/submit-bid-error-boundary.tsx).
Replaced the inline bid textarea on the job details page with the modal trigger and wired resolveFreelancerAddress + onSubmitted refresh behavior (apps/web/app/jobs/[id]/page.tsx).
Added unit tests that cover the schema and modal behavior (validation feedback, successful submission flow, and API error handling) (apps/web/components/jobs/__tests__/submit-bid-modal.test.tsx).
Testing


Added Vitest unit tests for schema and modal behavior, but running them locally in this container failed because vitest was not found when invoking npm --workspace apps/web run test -- components/jobs/__tests__/submit-bid-modal.test.tsx.
Ran ESLint in the container and it errored due to a hoisted module resolution issue for eslint/config, so lint checks could not complete locally.
The new tests are present and should run in CI or a properly bootstrapped developer environment using npm --workspace apps/web run test -- components/jobs/__tests__/submit-bid-modal.test.tsx and npm --workspace apps/web run lint.