### PR TITLE
feat(ui): show contract address in job summaries

### DIFF
--- a/apps/web/app/jobs/[id]/fund/page.tsx
+++ b/apps/web/app/jobs/[id]/fund/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { LoaderCircle, ShieldAlert } from "lucide-react";
 import { SiteShell } from "@/components/site-shell";
 import { api, type Job } from "@/lib/api";
-import { depositEscrow } from "@/lib/contracts";
+import { depositEscrow, getEscrowContractId } from "@/lib/contracts";
 import { formatUsdc } from "@/lib/format";
 import { TransactionPendingNotification } from "@/components/wallet/transaction-pending-notification";
 
@@ -176,6 +176,10 @@ export default function EscrowFundingPage() {
               <div className="flex justify-between gap-4">
                 <span>Contract value</span>
                 <span className="font-medium">{formatUsdc(job.budget_usdc)}</span>
+              </div>
+              <div className="flex justify-between gap-4">
+                <span>Escrow contract</span>
+                <span className="font-mono text-xs">{getEscrowContractId() || "Not configured"}</span>
               </div>
               <div className="flex justify-between gap-4">
                 <span>Platform fee (2%)</span>

--- a/apps/web/app/jobs/[id]/page.tsx
+++ b/apps/web/app/jobs/[id]/page.tsx
@@ -18,7 +18,7 @@ import { Stars } from "@/components/stars";
 import { JobDetailsSkeleton } from "@/components/ui/skeleton";
 import { useLiveJobWorkspace } from "@/hooks/use-live-job-workspace";
 import { api } from "@/lib/api";
-import { releaseFunds, openDispute } from "@/lib/contracts";
+import { releaseFunds, openDispute, getEscrowContractId } from "@/lib/contracts";
 import {
   formatDate,
   formatDateTime,
@@ -264,6 +264,15 @@ export default function JobDetailsPage() {
                   {formatDateTime(job.updated_at)}
                 </p>
               </div>
+            </div>
+
+            <div className="mt-4 rounded-[1.4rem] border border-slate-200 bg-slate-50 p-4">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                Escrow Contract
+              </p>
+              <p className="mt-2 font-mono text-xs text-slate-600 break-all">
+                {getEscrowContractId() || "Not configured"}
+              </p>
             </div>
 
             {workflowLocked ? (

--- a/apps/web/lib/contracts.ts
+++ b/apps/web/lib/contracts.ts
@@ -112,6 +112,16 @@ async function invokeEscrow(
 
 // ─── Public helpers ───────────────────────────────────────────────────────────
 
+/** Returns the escrow contract ID for display purposes. */
+export function getEscrowContractId(): string {
+  return ESCROW_CONTRACT_ID;
+}
+
+/** Returns the USDC contract ID for display purposes. */
+export function getUsdcContractId(): string {
+  return USDC_CONTRACT_ID;
+}
+
 /**
  * Calls escrow.deposit — locks USDC into the escrow for a given job.
  *


### PR DESCRIPTION
- Add getEscrowContractId() and getUsdcContractId() helper functions
- Display escrow contract address in funding summary page
- Show contract address in job details page with monospace formatting
- Improve transparency for blockchain interactions

Closes #185