### PR TITLE
feat: implement memo field support for job creation

### DIFF
--- a/apps/web/app/jobs/new/page.tsx
+++ b/apps/web/app/jobs/new/page.tsx
@@ -13,6 +13,7 @@ export default function NewJobPage() {
   const [description, setDescription] = useState("");
   const [budget, setBudget] = useState(1000);
   const [milestones, setMilestones] = useState(1);
+  const [memo, setMemo] = useState("");
   const [walletAddress, setWalletAddress] = useState("GD...CLIENT");
 
   const { submit, isSubmitting } = usePostJob();
@@ -43,6 +44,7 @@ export default function NewJobPage() {
         description,
         budgetUsdc: budget * 10_000_000,
         milestones,
+        memo: memo || undefined,
       });
     } catch {
       // Error handling is managed by usePostJob + toast system
@@ -123,6 +125,22 @@ export default function NewJobPage() {
                   disabled={isSubmitting || isTxInProgress}
                 />
               </div>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-semibold text-slate-700">
+                Memo (optional)
+              </label>
+              <input
+                type="text"
+                value={memo}
+                onChange={(event) => setMemo(event.target.value)}
+                className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-slate-950 outline-none transition focus:border-amber-400"
+                placeholder="Add a reference or internal note for this job"
+                maxLength={100}
+                id="job-memo"
+                disabled={isSubmitting || isTxInProgress}
+              />
             </div>
 
             {/* Transaction Tracker */}

--- a/apps/web/hooks/use-post-job.ts
+++ b/apps/web/hooks/use-post-job.ts
@@ -29,6 +29,7 @@ export interface PostJobInput {
   description: string;
   budgetUsdc: number;
   milestones: number;
+  memo?: string;
 }
 
 export function usePostJob() {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -148,6 +148,7 @@ export interface CreateJobBody {
   budget_usdc: number;
   milestones: number;
   client_address: string;
+  memo?: string;
 }
 
 export interface MarkFundedBody {


### PR DESCRIPTION
- Add optional memo field to job creation form
- Add memo to PostJobInput and CreateJobBody interfaces
- Update job creation page with memo input (100 char limit)
- Make memo optional - backward compatible with existing jobs

Closes #180