### PR TITLE
UI: Add Badge system for Job Status (#145)

### DIFF
--- a/apps/web/components/__tests__/status-badge.test.tsx
+++ b/apps/web/components/__tests__/status-badge.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { StatusBadge } from "../jobs/status-badge";
+
+describe("StatusBadge Component", () => {
+  it("renders pending status properly with default label", () => {
+    render(<StatusBadge status="pending" />);
+    const badge = screen.getByText(/Pending/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge.closest("div")).toHaveClass("text-amber-500");
+  });
+
+  it("renders success status properly with custom label", () => {
+    render(<StatusBadge status="success" label="Approved" />);
+    const badge = screen.getByText(/Approved/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge.closest("div")).toHaveClass("text-emerald-500");
+  });
+
+  it("renders failed status correctly", () => {
+    render(<StatusBadge status="failed" />);
+    const badge = screen.getByText(/Failed/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge.closest("div")).toHaveClass("text-red-500");
+  });
+});

--- a/apps/web/components/jobs/status-badge.tsx
+++ b/apps/web/components/jobs/status-badge.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { CheckCircle2, Clock, XCircle } from "lucide-react";
+
+export type JobStatus = "pending" | "success" | "failed";
+
+interface StatusBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  status: JobStatus;
+  label?: string;
+}
+
+export function StatusBadge({ status, label, className, ...props }: StatusBadgeProps) {
+  const statusConfig = {
+    pending: {
+      color: "border-amber-500/30 bg-amber-500/10 text-amber-500",
+      icon: <Clock className="w-3.5 h-3.5 mr-1.5" />,
+      text: label || "Pending",
+    },
+    success: {
+      color: "border-emerald-500/30 bg-emerald-500/10 text-emerald-500",
+      icon: <CheckCircle2 className="w-3.5 h-3.5 mr-1.5" />,
+      text: label || "Success",
+    },
+    failed: {
+      color: "border-red-500/30 bg-red-500/10 text-red-500",
+      icon: <XCircle className="w-3.5 h-3.5 mr-1.5" />,
+      text: label || "Failed",
+    },
+  };
+
+  const config = statusConfig[status];
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "rounded-full px-3 py-1 font-inter border shadow-sm backdrop-blur-sm transition-all duration-150",
+        config.color,
+        className
+      )}
+      {...props}
+    >
+      {config.icon}
+      <span className="font-medium tracking-tight text-[13px]">{config.text}</span>
+    </Badge>
+  );
+}


### PR DESCRIPTION
Fixes #145

**Description**
This PR encapsulates application-state boundaries into the marketplace's primary visual `StatusBadge`. We've strictly mapped internal states directly to dynamic Tailwind variables providing immediate clarity and professional trust.

**Changes Included**
- Bound "Success" mapping strictly to `Emerald-500`.
- Bound "Pending" scenarios mapping dynamically to `Amber-500` loops.
- Adhered rigidly to the 150ms smooth transition expectations over the core Shadcn baseline formats.
- Covered fully with Vitest functional DOM assertions under `apps/web/components/__tests__/status-badge.test.tsx`.
