### PR TITLE
fix: add APP_ENV-aware backend environment loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ cp apps/web/.env.example apps/web/.env.local
 
 # backend
 cp backend/.env.example backend/.env
+# optional per-environment overrides
+cp backend/.env.example backend/.env.development
 ```
+
+Backend env loading precedence:
+
+1. Existing process environment variables
+2. `backend/.env.<APP_ENV>` (or `.env.<RUST_ENV>`)
+3. `backend/.env`
 
 ### Run Locally
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
+APP_ENV=development
 DATABASE_URL=postgres://lance:lance@localhost:5432/lance
 OPENCLAW_API_KEY=TODO_fill_in
 OPENCLAW_BASE_URL=https://api.openclaw.ai/v1

--- a/backend/src/env_config.rs
+++ b/backend/src/env_config.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use dotenvy::from_path_iter;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub struct EnvBootstrap {
+    pub app_env: String,
+    pub loaded_files: Vec<String>,
+}
+
+pub fn load_backend_environment() -> Result<EnvBootstrap> {
+    let app_env = std::env::var("APP_ENV")
+        .or_else(|_| std::env::var("RUST_ENV"))
+        .unwrap_or_else(|_| "development".to_string());
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let initial_env_keys = snapshot_env_keys();
+    let mut loaded_files = Vec::new();
+
+    let base_env = root.join(".env");
+    if base_env.is_file() {
+        apply_env_file(&base_env, false, &initial_env_keys)?;
+        loaded_files.push(display_path(&base_env, &root));
+    }
+
+    let env_specific = root.join(format!(".env.{app_env}"));
+    if env_specific.is_file() {
+        // Environment-specific values should override `.env`,
+        // but never override values already supplied by the parent process.
+        apply_env_file(&env_specific, true, &initial_env_keys)?;
+        loaded_files.push(display_path(&env_specific, &root));
+    }
+
+    Ok(EnvBootstrap {
+        app_env,
+        loaded_files,
+    })
+}
+
+fn snapshot_env_keys() -> HashSet<String> {
+    std::env::vars().map(|(key, _)| key).collect()
+}
+
+fn apply_env_file(path: &Path, allow_override_for_loaded_values: bool, initial_env_keys: &HashSet<String>) -> Result<()> {
+    let iter = from_path_iter(path)?;
+    for item in iter {
+        let (key, value) = item?;
+
+        let should_set = if allow_override_for_loaded_values {
+            !initial_env_keys.contains(&key)
+        } else {
+            std::env::var_os(&key).is_none()
+        };
+
+        if should_set {
+            std::env::set_var(key, value);
+        }
+    }
+
+    Ok(())
+}
+
+fn display_path(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .map(|relative| relative.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string())
+}

--- a/backend/src/env_config.rs
+++ b/backend/src/env_config.rs
@@ -42,7 +42,11 @@ fn snapshot_env_keys() -> HashSet<String> {
     std::env::vars().map(|(key, _)| key).collect()
 }
 
-fn apply_env_file(path: &Path, allow_override_for_loaded_values: bool, initial_env_keys: &HashSet<String>) -> Result<()> {
+fn apply_env_file(
+    path: &Path,
+    allow_override_for_loaded_values: bool,
+    initial_env_keys: &HashSet<String>,
+) -> Result<()> {
     let iter = from_path_iter(path)?;
     for item in iter {
         let (key, value) = item?;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,11 +1,11 @@
 use axum::Router;
-use dotenvy::dotenv;
 use sqlx::postgres::PgPoolOptions;
 use std::net::SocketAddr;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod db;
+mod env_config;
 mod error;
 mod indexer;
 mod middleware;
@@ -20,7 +20,7 @@ pub use db::AppState;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dotenv().ok();
+    let env_bootstrap = env_config::load_backend_environment()?;
 
     tracing_subscriber::registry()
         .with(
@@ -29,6 +29,12 @@ async fn main() -> anyhow::Result<()> {
         )
         .with(tracing_subscriber::fmt::layer())
         .init();
+
+    tracing::info!(
+        app_env = %env_bootstrap.app_env,
+        loaded_env_files = ?env_bootstrap.loaded_files,
+        "backend environment initialized",
+    );
 
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let pool = PgPoolOptions::new()

--- a/docs/running-the-stack.md
+++ b/docs/running-the-stack.md
@@ -37,6 +37,7 @@ Create backend env file:
 
 ```bash
 cp backend/.env.example backend/.env
+cp backend/.env.example backend/.env.development
 ```
 
 Create web env file:
@@ -47,6 +48,7 @@ cp apps/web/.env.example apps/web/.env.local
 
 Important backend variables:
 
+- `APP_ENV`: optional environment selector (defaults to `development`). Backend loads `.env` then `.env.<APP_ENV>` and keeps shell-provided vars highest priority.
 - `DATABASE_URL`: Postgres connection string
 - `SOROBAN_RPC_URL` or `STELLAR_RPC_URL`: Soroban RPC endpoint
 - `JUDGE_AUTHORITY_SECRET`: signing key used by backend judge/contract actions


### PR DESCRIPTION
Closes #209
Closes #204
Closes #186

## Summary
- add backend environment bootstrap with layered loading from .env and .env.<APP_ENV> (or .env.<RUST_ENV>)
- preserve shell-provided variables as highest-priority values while allowing env-specific files to override base .env`n- initialize env loading before tracing/database startup and log active environment + loaded files
- document environment-specific backend configuration in README.md and docs/running-the-stack.md`n- add APP_ENV=development to ackend/.env.example`n
## Testing
- unable to run backend tests in this environment due local Rust toolchain/rustup download errors (ust-docs install failure)
