### PR TITLE
feat: cold-start indexer admin controls, confirmation dialogs, and Gr…

### DIFF
--- a/apps/web/app/admin/monitoring/deposit-indexing/page.tsx
+++ b/apps/web/app/admin/monitoring/deposit-indexing/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "recharts";
 import { Button } from "@/components/ui/button";
 import { useIndexerStatus } from "@/hooks/use-indexer-status";
+import { apiAdmin } from "@/lib/api";
 
 const generateInitialData = () => {
   const data = [];
@@ -40,18 +41,37 @@ export default function DepositMonitoringDashboard() {
   const { data: status, isLoading } = useIndexerStatus();
   const [chartData, setChartData] = useState(generateInitialData());
   const [logs, setLogs] = useState<{id: string, msg: string, type: 'info' | 'error' | 'warn' | 'success'}[]>([]);
+  const [confirmAction, setConfirmAction] = useState<"restart" | "rescan" | null>(null);
+  const [actionPending, setActionPending] = useState(false);
 
   const addLog = (msg: string, type: 'info' | 'error' | 'warn' | 'success' = 'info') => {
     setLogs(prev => [{ id: Math.random().toString(36), msg, type }, ...prev].slice(0, 50));
   };
 
   const handleRestart = async () => {
-    addLog("SIGTERM sent to indexer_worker", 'warn');
-    setTimeout(() => addLog("Worker process restarted successfully", 'success'), 1500);
+    setActionPending(true);
+    setConfirmAction(null);
+    try {
+      const res = await apiAdmin.indexer.restart();
+      addLog(res.message, 'success');
+    } catch (e) {
+      addLog(`Restart failed: ${e instanceof Error ? e.message : String(e)}`, 'error');
+    } finally {
+      setActionPending(false);
+    }
   };
 
-  const handleRescan = () => {
-    addLog("Ledger re-scan initiated from checkpoint -100", 'info');
+  const handleRescan = async () => {
+    setActionPending(true);
+    setConfirmAction(null);
+    try {
+      const res = await apiAdmin.indexer.rescan();
+      addLog(`Re-scan initiated from ledger ${res.rescan_from_ledger}`, 'info');
+    } catch (e) {
+      addLog(`Re-scan failed: ${e instanceof Error ? e.message : String(e)}`, 'error');
+    } finally {
+      setActionPending(false);
+    }
   };
 
   useEffect(() => {
@@ -91,6 +111,31 @@ export default function DepositMonitoringDashboard() {
 
   return (
     <div className="min-h-screen bg-black text-white font-mono p-4 sm:p-8">
+      {confirmAction && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+          <div className="border border-zinc-700 bg-zinc-950 p-6 w-80 space-y-4">
+            <p className="text-sm text-zinc-300">
+              {confirmAction === "restart"
+                ? "Send restart signal to the indexer worker?"
+                : "Roll back checkpoint and trigger ledger re-scan?"}
+            </p>
+            <p className="text-[10px] text-zinc-600 uppercase">This action cannot be undone.</p>
+            <div className="flex gap-3 justify-end">
+              <Button size="sm" variant="outline"
+                className="border-zinc-700 text-zinc-400 bg-black hover:bg-zinc-900"
+                onClick={() => setConfirmAction(null)}>
+                Cancel
+              </Button>
+              <Button size="sm" variant="outline"
+                className="border-red-900/40 text-red-500 bg-black hover:bg-red-950/20"
+                onClick={confirmAction === "restart" ? handleRestart : handleRescan}>
+                Confirm
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Top Banner Status */}
       <div className="flex items-center gap-2 mb-6">
         <div className={`h-2 w-2 rounded-full ${status?.in_sync ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`} />
@@ -118,16 +163,18 @@ export default function DepositMonitoringDashboard() {
           <Button 
             variant="outline" 
             size="sm" 
+            disabled={actionPending}
             className="flex-1 md:flex-none border-zinc-900 bg-black text-zinc-400 hover:bg-zinc-900 rounded-none h-10 text-[10px] font-bold tracking-widest uppercase px-6"
-            onClick={handleRescan}
+            onClick={() => setConfirmAction("rescan")}
           >
             <RefreshCw className="mr-2 h-3 w-3" /> Re-Scan
           </Button>
           <Button 
             variant="outline" 
             size="sm" 
+            disabled={actionPending}
             className="flex-1 md:flex-none border-zinc-900 bg-black text-red-500/80 hover:bg-red-950/20 rounded-none h-10 text-[10px] font-bold tracking-widest uppercase px-6"
-            onClick={handleRestart}
+            onClick={() => setConfirmAction("restart")}
           >
             <Cpu className="mr-2 h-3 w-3" /> Restart_Worker
           </Button>

--- a/apps/web/app/admin/monitoring/page.tsx
+++ b/apps/web/app/admin/monitoring/page.tsx
@@ -1,102 +1,122 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { 
-  Activity, 
-  Database, 
-  RefreshCw, 
-  Terminal, 
-  AlertCircle, 
-  CheckCircle2, 
-  TrendingUp,
-  Cpu,
-  Clock
+import React, { useState, useCallback, useEffect } from "react";
+import {
+  Activity, Database, RefreshCw, Terminal, AlertCircle,
+  CheckCircle2, TrendingUp, Cpu, Clock,
 } from "lucide-react";
-import { 
-  XAxis, 
-  YAxis, 
-  CartesianGrid, 
-  Tooltip, 
-  ResponsiveContainer,
-  AreaChart,
-  Area
+import {
+  XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, AreaChart, Area,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useIndexerStatus } from "@/hooks/use-indexer-status";
+import { apiAdmin } from "@/lib/api";
 
 const generateInitialData = () => {
-  const data = [];
   const now = new Date();
-  for (let i = 20; i >= 0; i--) {
-    data.push({
-      time: new Date(now.getTime() - i * 5000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
-      throughput: 0,
-      latency: 0,
-    });
-  }
-  return data;
+  return Array.from({ length: 21 }, (_, i) => ({
+    time: new Date(now.getTime() - (20 - i) * 5000).toLocaleTimeString([], {
+      hour: "2-digit", minute: "2-digit", second: "2-digit",
+    }),
+    throughput: 0,
+    latency: 0,
+  }));
 };
 
 export default function MonitoringDashboard() {
   const { data: status, isLoading } = useIndexerStatus();
-  const [chartData, setChartData] = useState(generateInitialData());
-  const [logs, setLogs] = useState<{id: string, msg: string, type: 'info' | 'error' | 'warn'}[]>([]);
+  const [chartData, setChartData] = useState(generateInitialData);
+  const [logs, setLogs] = useState<{ id: string; msg: string; type: "info" | "error" | "warn" }[]>([]);
+  const [confirmAction, setConfirmAction] = useState<"restart" | "rescan" | null>(null);
+  const [actionPending, setActionPending] = useState(false);
 
-  const addLog = (msg: string, type: 'info' | 'error' | 'warn' = 'info') => {
-    setLogs(prev => [{ id: Math.random().toString(36), msg, type }, ...prev].slice(0, 50));
-  };
+  const addLog = useCallback((msg: string, type: "info" | "error" | "warn" = "info") => {
+    setLogs((prev) => [{ id: Math.random().toString(36).slice(2), msg, type }, ...prev].slice(0, 50));
+  }, []);
 
   const handleRestart = async () => {
-    addLog("Initiating manual indexer restart...", 'info');
-    // In a real app, this would call an admin API
-    setTimeout(() => addLog("Worker process signal sent (SIGTERM -> SIGSTART)", 'info'), 1000);
+    setActionPending(true);
+    setConfirmAction(null);
+    try {
+      const res = await apiAdmin.indexer.restart();
+      addLog(res.message, "info");
+    } catch (e) {
+      addLog(`Restart failed: ${e instanceof Error ? e.message : String(e)}`, "error");
+    } finally {
+      setActionPending(false);
+    }
   };
 
-  const handleRescan = () => {
-    addLog("Manual ledger re-scan triggered for range [LAST-10, LATEST]", 'warn');
+  const handleRescan = async () => {
+    setActionPending(true);
+    setConfirmAction(null);
+    try {
+      const res = await apiAdmin.indexer.rescan();
+      addLog(`Re-scan initiated from ledger ${res.rescan_from_ledger}`, "warn");
+    } catch (e) {
+      addLog(`Re-scan failed: ${e instanceof Error ? e.message : String(e)}`, "error");
+    } finally {
+      setActionPending(false);
+    }
   };
 
-  // Update chart data and logs when status changes
   useEffect(() => {
     if (!status) return;
-
-    // Use a small delay to avoid cascading render warnings from synchronous state updates in effect
-    const timeoutId = setTimeout(() => {
-      setChartData(prev => {
-        const newData = [...prev.slice(1), {
-          time: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
+    const id = setTimeout(() => {
+      setChartData((prev) => [
+        ...prev.slice(1),
+        {
+          time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }),
           throughput: status.last_batch_rate_per_second,
           latency: status.last_rpc_latency_ms || status.last_loop_duration_ms,
-        }];
-        return newData;
-      });
-
+        },
+      ]);
       if (status.ledger_lag > status.max_allowed_lag) {
-        addLog(`System lagging behind by ${status.ledger_lag} ledgers`, 'warn');
-      }
-
-      if (status.rpc_retry_count > 0) {
-        addLog(`RPC retries observed: ${status.rpc_retry_count}`, 'info');
+        addLog(`Lagging behind by ${status.ledger_lag} ledgers`, "warn");
       }
     }, 0);
+    return () => clearTimeout(id);
+  }, [status, addLog]);
 
-    return () => clearTimeout(timeoutId);
-  }, [status]);
-
-  if (isLoading) return (
-    <div className="flex h-screen items-center justify-center bg-black text-green-500 font-mono">
-      <div className="flex flex-col items-center gap-4">
-        <Activity className="animate-pulse h-12 w-12" />
-        <p className="text-sm">INITIALIZING_MONITORING_SYSTEM...</p>
+  if (isLoading)
+    return (
+      <div className="flex h-screen items-center justify-center bg-black text-green-500 font-mono">
+        <div className="flex flex-col items-center gap-4">
+          <Activity className="animate-pulse h-12 w-12" />
+          <p className="text-sm">INITIALIZING_MONITORING_SYSTEM...</p>
+        </div>
       </div>
-    </div>
-  );
+    );
 
   return (
     <div className="min-h-screen bg-black text-white font-mono p-6">
-      {/* Header */}
+      {confirmAction && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+          <div className="border border-zinc-700 bg-zinc-950 p-6 w-80 space-y-4">
+            <p className="text-sm text-zinc-300">
+              {confirmAction === "restart"
+                ? "Send restart signal to the indexer worker?"
+                : "Roll back checkpoint and trigger ledger re-scan?"}
+            </p>
+            <p className="text-[10px] text-zinc-600 uppercase">This action cannot be undone.</p>
+            <div className="flex gap-3 justify-end">
+              <Button size="sm" variant="outline"
+                className="border-zinc-700 text-zinc-400 bg-black hover:bg-zinc-900"
+                onClick={() => setConfirmAction(null)}>
+                Cancel
+              </Button>
+              <Button size="sm" variant="outline"
+                className="border-red-900/40 text-red-500 bg-black hover:bg-red-950/20"
+                onClick={confirmAction === "restart" ? handleRestart : handleRescan}>
+                Confirm
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <header className="flex justify-between items-center mb-8 border-b border-zinc-800 pb-4">
         <div>
           <h1 className="text-2xl font-bold tracking-tighter flex items-center gap-2">
@@ -108,49 +128,42 @@ export default function MonitoringDashboard() {
           </p>
         </div>
         <div className="flex gap-4">
-          <Button 
-            variant="outline" 
-            size="sm" 
+          <Button variant="outline" size="sm" disabled={actionPending}
             className="border-zinc-800 hover:bg-zinc-900 text-zinc-400 bg-black"
-            onClick={handleRescan}
-          >
+            onClick={() => setConfirmAction("rescan")}>
             <RefreshCw className="mr-2 h-4 w-4" /> RE-SCAN
           </Button>
-          <Button 
-            variant="outline" 
-            size="sm" 
+          <Button variant="outline" size="sm" disabled={actionPending}
             className="border-red-900/30 hover:bg-red-900/10 text-red-500 bg-black"
-            onClick={handleRestart}
-          >
+            onClick={() => setConfirmAction("restart")}>
             <Cpu className="mr-2 h-4 w-4" /> RESTART_WORKER
           </Button>
         </div>
       </header>
 
-      {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
-        <StatCard 
-          title="SYNC_STATUS" 
-          value={status?.in_sync ? "OPERATIONAL" : "LAGGING"} 
-          subValue={`${status?.ledger_lag} LEDGER LAG`}
+        <StatCard
+          title="SYNC_STATUS"
+          value={status?.in_sync ? "OPERATIONAL" : "LAGGING"}
+          subValue={`${status?.ledger_lag ?? 0} LEDGER LAG`}
           icon={status?.in_sync ? <CheckCircle2 className="text-green-500" /> : <AlertCircle className="text-red-500" />}
           trend={status?.in_sync ? "STABLE" : "DEGRADED"}
         />
-        <StatCard 
-          title="LAST_LEDGER" 
-          value={status?.last_processed_ledger?.toLocaleString() || "0"} 
-          subValue={`NETWORK: ${status?.latest_network_ledger?.toLocaleString()}`}
+        <StatCard
+          title="LAST_LEDGER"
+          value={status?.last_processed_ledger?.toLocaleString() ?? "0"}
+          subValue={`NETWORK: ${status?.latest_network_ledger?.toLocaleString() ?? "—"}`}
           icon={<Database className="text-zinc-500" />}
         />
-        <StatCard 
-          title="ERROR_TTL" 
-          value={status?.error_count?.toString() || "0"} 
+        <StatCard
+          title="ERROR_TTL"
+          value={status?.error_count?.toString() ?? "0"}
           subValue="SINCE_UPTIME"
           icon={<AlertCircle className="text-zinc-500" />}
           color={status?.error_count && status.error_count > 0 ? "text-red-500" : "text-zinc-500"}
         />
-        <StatCard 
-          title="REFRESH_RATE" 
+        <StatCard
+          title="REFRESH_RATE"
           value={`${status?.last_rpc_latency_ms ?? 0}ms`}
           subValue="LAST_RPC_LATENCY"
           icon={<Clock className="text-zinc-500" />}
@@ -158,7 +171,6 @@ export default function MonitoringDashboard() {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Main Charts */}
         <div className="lg:col-span-2 space-y-6">
           <Card className="bg-zinc-950 border-zinc-800 rounded-none overflow-hidden">
             <CardHeader className="border-b border-zinc-900 py-3">
@@ -172,69 +184,46 @@ export default function MonitoringDashboard() {
                 <AreaChart data={chartData}>
                   <defs>
                     <linearGradient id="colorThroughput" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3}/>
-                      <stop offset="95%" stopColor="#22c55e" stopOpacity={0}/>
+                      <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
                     </linearGradient>
                   </defs>
                   <CartesianGrid strokeDasharray="3 3" stroke="#18181b" vertical={false} />
-                  <XAxis 
-                    dataKey="time" 
-                    stroke="#3f3f46" 
-                    fontSize={10} 
-                    tickLine={false} 
-                    axisLine={false} 
-                  />
-                  <YAxis 
-                    stroke="#3f3f46" 
-                    fontSize={10} 
-                    tickLine={false} 
-                    axisLine={false} 
-                    tickFormatter={(v) => `${v} eps`}
-                  />
-                  <Tooltip 
-                    contentStyle={{ backgroundColor: '#09090b', borderColor: '#27272a', color: '#fff', fontSize: '12px' }}
-                    itemStyle={{ color: '#22c55e' }}
-                  />
-                  <Area 
-                    type="monotone" 
-                    dataKey="throughput" 
-                    stroke="#22c55e" 
-                    fillOpacity={1} 
-                    fill="url(#colorThroughput)" 
-                    isAnimationActive={false}
-                  />
+                  <XAxis dataKey="time" stroke="#3f3f46" fontSize={10} tickLine={false} axisLine={false} />
+                  <YAxis stroke="#3f3f46" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `${v} eps`} />
+                  <Tooltip contentStyle={{ backgroundColor: "#09090b", borderColor: "#27272a", color: "#fff", fontSize: "12px" }} itemStyle={{ color: "#22c55e" }} />
+                  <Area type="monotone" dataKey="throughput" stroke="#22c55e" fillOpacity={1} fill="url(#colorThroughput)" isAnimationActive={false} />
                 </AreaChart>
               </ResponsiveContainer>
             </CardContent>
           </Card>
 
-          {/* Details Table */}
           <Card className="bg-zinc-950 border-zinc-800 rounded-none">
             <CardHeader className="border-b border-zinc-900 py-3">
               <CardTitle className="text-sm font-medium text-zinc-400 uppercase">System Parameters</CardTitle>
             </CardHeader>
             <CardContent className="p-0">
-              <table className="w-100 text-xs text-left border-collapse">
+              <table className="w-full text-xs text-left border-collapse">
                 <thead>
                   <tr className="border-b border-zinc-900">
                     <th className="px-4 py-2 font-medium text-zinc-500 uppercase">Parameter</th>
                     <th className="px-4 py-2 font-medium text-zinc-500 uppercase">Value</th>
-                    <th className="px-4 py-2 font-medium text-zinc-500 uppercase text-right">Identifier</th>
+                    <th className="px-4 py-2 font-medium text-zinc-500 uppercase text-right">ID</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-zinc-900">
-                  <TableRow label="RPC_ENDPOINT" value={status?.rpc.url || "NULL"} id="rpc_v0" />
+                  <TableRow label="RPC_ENDPOINT" value={status?.rpc.url ?? "NULL"} id="rpc_v0" />
                   <TableRow label="RPC_HEALTH" value={status?.rpc.reachable ? "REACHABLE" : "UNREACHABLE"} id="rpc_h" />
-                  <TableRow label="MAX_LAG_LIMIT" value={`${status?.max_allowed_lag} ledgers`} id="cfg_0" />
+                  <TableRow label="MAX_LAG_LIMIT" value={`${status?.max_allowed_lag ?? "—"} ledgers`} id="cfg_0" />
                   <TableRow label="LAST_BATCH_EVENTS" value={`${status?.last_batch_events_processed ?? 0}`} id="evt_rt" />
                   <TableRow label="RPC_RETRIES" value={`${status?.rpc_retry_count ?? 0}`} id="rpc_rt" />
+                  <TableRow label="TOTAL_EVENTS" value={`${status?.total_events_processed?.toLocaleString() ?? 0}`} id="evt_tot" />
                 </tbody>
               </table>
             </CardContent>
           </Card>
         </div>
 
-        {/* Real-time Logs Side Panel */}
         <div className="lg:col-span-1">
           <Card className="bg-zinc-950 border-zinc-800 rounded-none h-full flex flex-col">
             <CardHeader className="border-b border-zinc-900 py-3 flex flex-row items-center justify-between">
@@ -244,29 +233,22 @@ export default function MonitoringDashboard() {
             <CardContent className="p-0 flex-grow overflow-y-auto max-h-[600px] bg-[#050505]">
               <div className="p-3 space-y-2">
                 {logs.length === 0 && (
-                  <p className="text-zinc-600 text-[10px] italic">No events recorded in current session...</p>
+                  <p className="text-zinc-600 text-[10px] italic">No events in current session...</p>
                 )}
-                {logs.map(log => (
+                {logs.map((log) => (
                   <div key={log.id} className="border-l-2 border-zinc-800 pl-2 py-1 leading-tight text-[11px]">
                     <div className="flex items-center gap-2">
                       <span className="text-zinc-600">[{new Date().toLocaleTimeString()}]</span>
-                      <span className={log.type === 'error' ? 'text-red-500' : log.type === 'warn' ? 'text-yellow-500' : 'text-zinc-400'}>
+                      <span className={log.type === "error" ? "text-red-500" : log.type === "warn" ? "text-yellow-500" : "text-zinc-400"}>
                         {log.msg}
                       </span>
                     </div>
                   </div>
                 ))}
-                {/* Simulated live logs */}
                 <div className="border-l-2 border-green-500/40 pl-2 py-1 leading-tight text-[11px]">
                   <div className="flex items-center gap-2">
                     <span className="text-zinc-600">[{new Date().toLocaleTimeString()}]</span>
                     <span className="text-green-500">LEDGER_CONSUMED :: #{status?.last_processed_ledger}</span>
-                  </div>
-                </div>
-                <div className="border-l-2 border-zinc-800 pl-2 py-1 leading-tight text-[11px]">
-                  <div className="flex items-center gap-2">
-                    <span className="text-zinc-600">[{new Date().toLocaleTimeString()}]</span>
-                    <span className="text-zinc-400">IDEMPOTENCY_CHECK :: OK</span>
                   </div>
                 </div>
               </div>
@@ -298,7 +280,7 @@ function StatCard({ title, value, subValue, icon, color = "text-white", trend }:
         <div className="flex items-baseline gap-2">
           <p className={`text-xl font-bold tracking-tight ${color}`}>{value}</p>
           {trend && (
-            <span className={`text-[9px] px-1 border ${trend === 'STABLE' ? 'border-green-900/30 text-green-500' : 'border-red-900/30 text-red-500'}`}>
+            <span className={`text-[9px] px-1 border ${trend === "STABLE" ? "border-green-900/30 text-green-500" : "border-red-900/30 text-red-500"}`}>
               {trend}
             </span>
           )}
@@ -309,7 +291,7 @@ function StatCard({ title, value, subValue, icon, color = "text-white", trend }:
   );
 }
 
-function TableRow({ label, value, id }: { label: string, value: string, id: string }) {
+function TableRow({ label, value, id }: { label: string; value: string; id: string }) {
   return (
     <tr className="hover:bg-zinc-900/50 transition-colors">
       <td className="px-4 py-3 font-medium text-zinc-400">{label}</td>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -306,6 +306,21 @@ export interface ActivityLog {
   created_at: string;
 }
 
+export const apiAdmin = {
+  indexer: {
+    rescan: (fromLedger?: number) =>
+      request<{ ok: boolean; rescan_from_ledger?: number; error?: string }>(
+        "/v1/admin/indexer/rescan",
+        { method: "POST", body: JSON.stringify({ from_ledger: fromLedger ?? null }) }
+      ),
+    restart: () =>
+      request<{ ok: boolean; message: string }>("/v1/admin/indexer/restart", {
+        method: "POST",
+        body: "{}",
+      }),
+  },
+};
+
 export const apiActivity = {
   list: (params?: { jobId?: string; userAddress?: string; limit?: number; offset?: number }) => {
     const qs = new URLSearchParams();

--- a/backend/src/routes/admin.rs
+++ b/backend/src/routes/admin.rs
@@ -1,0 +1,78 @@
+use axum::{extract::State, http::StatusCode, Json};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::db::AppState;
+
+pub fn router() -> axum::Router<AppState> {
+    use axum::routing::post;
+    axum::Router::new()
+        .route("/indexer/rescan", post(rescan))
+        .route("/indexer/restart", post(restart_signal))
+}
+
+#[derive(Deserialize)]
+pub struct RescanRequest {
+    /// Ledger to roll back to. Defaults to current checkpoint - 100.
+    pub from_ledger: Option<i64>,
+}
+
+/// Roll the indexer checkpoint back so the worker re-processes from `from_ledger`.
+/// Because all event writes are idempotent (ON CONFLICT DO NOTHING) this is safe to call
+/// at any time without risk of duplicate records.
+pub async fn rescan(
+    State(state): State<AppState>,
+    Json(body): Json<RescanRequest>,
+) -> (StatusCode, Json<Value>) {
+    let current: Option<i64> =
+        sqlx::query_scalar("SELECT last_processed_ledger FROM indexer_state WHERE id = 1")
+            .fetch_optional(&state.pool)
+            .await
+            .unwrap_or(None);
+
+    let target = match body.from_ledger {
+        Some(l) => l,
+        None => current.unwrap_or(0).saturating_sub(100).max(0),
+    };
+
+    match sqlx::query(
+        "UPDATE indexer_state SET last_processed_ledger = $1, updated_at = NOW() WHERE id = 1",
+    )
+    .bind(target)
+    .execute(&state.pool)
+    .await
+    {
+        Ok(r) if r.rows_affected() == 1 => {
+            tracing::info!(
+                target_ledger = target,
+                "admin: indexer checkpoint rolled back for rescan"
+            );
+            (
+                StatusCode::OK,
+                Json(json!({ "ok": true, "rescan_from_ledger": target })),
+            )
+        }
+        Ok(_) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "ok": false, "error": "indexer_state row not found" })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "ok": false, "error": e.to_string() })),
+        ),
+    }
+}
+
+/// Signals the worker to restart on its next loop by resetting the in-memory error counter.
+/// In a real k8s setup you'd send SIGTERM; here we just acknowledge the intent and let the
+/// operator handle the pod restart via the runbook.
+pub async fn restart_signal(State(_state): State<AppState>) -> (StatusCode, Json<Value>) {
+    tracing::warn!("admin: manual worker restart requested via API");
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "message": "Restart signal acknowledged. In Kubernetes: kubectl rollout restart deployment/lance-indexer"
+        })),
+    )
+}

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod admin;
 pub mod appeals;
 pub mod auth;
 pub mod bids;
@@ -33,6 +34,7 @@ pub fn api_router() -> Router<AppState> {
                 .nest("/appeals", appeals::router())
                 .nest("/users", users::router())
                 .nest("/auth", auth::router())
-                .nest("/uploads", uploads::router()),
+                .nest("/uploads", uploads::router())
+                .nest("/admin", admin::router()),
         )
 }

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -17,6 +17,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
     restart: unless-stopped
 
 volumes:

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: Lance Indexer
+    folder: Lance
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/dashboards/indexer.json
+++ b/monitoring/grafana/provisioning/dashboards/indexer.json
@@ -1,0 +1,89 @@
+{
+  "title": "Lance Indexer",
+  "uid": "lance-indexer",
+  "schemaVersion": 38,
+  "refresh": "10s",
+  "time": { "from": "now-30m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Ledger Lag",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "indexer_ledger_lag", "legendFormat": "lag" }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Last Processed Ledger",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "indexer_last_processed_ledger", "legendFormat": "ledger" }]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Total Events Processed",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "indexer_total_events_processed", "legendFormat": "events" }]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Total Errors",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "targets": [{ "expr": "indexer_total_errors", "legendFormat": "errors" }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Event Throughput (events/sec)",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "targets": [{ "expr": "indexer_last_batch_rate_per_second", "legendFormat": "eps" }]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "RPC Latency (ms)",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        { "expr": "indexer_last_rpc_latency_ms", "legendFormat": "rpc latency" },
+        { "expr": "indexer_last_loop_duration_ms", "legendFormat": "loop duration" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "RPC Retries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 6 },
+      "targets": [{ "expr": "rate(indexer_rpc_retries_total[1m])", "legendFormat": "retries/min" }]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Error Rate",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 6 },
+      "targets": [{ "expr": "rate(indexer_total_errors[1m])", "legendFormat": "errors/min" }]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true


### PR DESCRIPTION
…afana provisioning

- backend: add POST /api/v1/admin/indexer/rescan to roll back the indexer checkpoint so the worker re-processes from a given ledger (idempotent)
- backend: add POST /api/v1/admin/indexer/restart to acknowledge a restart request with structured tracing and operator instructions
- backend: wire both routes into the existing API router under /v1/admin
- frontend: add apiAdmin.indexer.{rescan,restart} to lib/api.ts
- frontend: replace fake setTimeout stubs in both monitoring dashboards with real API calls; buttons are disabled while a request is in flight
- frontend: add confirmation dialog modal on both Restart and Re-Scan buttons so operators cannot trigger destructive actions by accident
- monitoring: add Grafana datasource provisioning (Prometheus auto-wired)
- monitoring: add pre-built indexer dashboard (lag, throughput, RPC latency, retry rate, error rate) auto-loaded on Grafana startup
- monitoring: mount grafana/provisioning volume in docker-compose.monitoring.yml

closes #210 