### PR TITLE
feat: structured logging with JSON format support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ uuid               = { version = "1", features = ["v4", "serde"] }
 chrono             = { version = "0.4", features = ["serde"] }
 reqwest            = { version = "0.12", features = ["json", "multipart"] }
 tracing            = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 anyhow             = "1"
 thiserror          = "1"
 dotenvy            = "0.15"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,5 @@ REPUTATION_CONTRACT_ID=TODO_after_deploy
 JOB_REGISTRY_CONTRACT_ID=TODO_after_deploy
 PORT=3001
 RUST_LOG=backend=debug,tower_http=debug
+# Set to "json" for structured JSON log output (e.g. in production)
+LOG_FORMAT=pretty

--- a/backend/src/ledger_follower.rs
+++ b/backend/src/ledger_follower.rs
@@ -266,11 +266,15 @@ impl LedgerFollower {
     }
 }
 
-#[tracing::instrument(skip(tx, event), fields(event_id = event.get("id").and_then(Value::as_str).unwrap_or("")))]
+#[tracing::instrument(skip(tx, event), fields(event_id = tracing::field::Empty))]
 async fn process_event_side_effects(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     event: &Value,
 ) -> Result<()> {
+    if let Some(id) = event.get("id").and_then(Value::as_str) {
+        tracing::Span::current().record("event_id", id);
+    }
+
     let topics = event.get("topic").and_then(Value::as_array);
     let first_topic = topics
         .and_then(|items| items.first())

--- a/backend/src/ledger_follower.rs
+++ b/backend/src/ledger_follower.rs
@@ -121,6 +121,7 @@ impl LedgerFollower {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn next_cycle(&mut self) -> Result<LedgerCycle> {
         let mut last_processed_ledger: i64 =
             sqlx::query_scalar("SELECT last_processed_ledger FROM indexer_state WHERE id = 1")
@@ -265,6 +266,7 @@ impl LedgerFollower {
     }
 }
 
+#[tracing::instrument(skip(tx, event), fields(event_id = event.get("id").and_then(Value::as_str).unwrap_or("")))]
 async fn process_event_side_effects(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     event: &Value,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -25,13 +25,24 @@ pub use db::AppState;
 async fn main() -> anyhow::Result<()> {
     let env_bootstrap = env_config::load_backend_environment()?;
 
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "backend=debug,tower_http=debug".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "backend=debug,tower_http=debug".into());
+
+    let use_json = std::env::var("LOG_FORMAT")
+        .map(|v| v.eq_ignore_ascii_case("json"))
+        .unwrap_or(false);
+
+    if use_json {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(tracing_subscriber::fmt::layer().json())
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+    }
 
     tracing::info!(
         app_env = %env_bootstrap.app_env,
@@ -57,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|_| "3001".to_string())
         .parse()?;
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    tracing::info!("🚀 Backend listening on {addr}");
+    tracing::info!(addr = %addr, "backend listening");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -13,7 +13,7 @@ pub async fn run_judge_worker(pool: PgPool) {
 
     loop {
         if let Err(e) = process_open_disputes(&pool, &judge, stellar.as_ref()).await {
-            tracing::error!("judge worker error: {e}");
+            tracing::error!(error = %e, "judge worker cycle failed");
         }
         tokio::time::sleep(Duration::from_secs(30)).await;
     }
@@ -31,19 +31,29 @@ async fn process_open_disputes(
 
     for (dispute_id, job_id) in disputes {
         if let Err(e) = process_dispute(pool, judge, stellar, dispute_id, job_id).await {
-            tracing::error!("dispute {dispute_id} failed: {e}");
+            tracing::error!(
+                %dispute_id,
+                %job_id,
+                error = %e,
+                "dispute processing failed",
+            );
             if let Err(e2) = sqlx::query("UPDATE disputes SET status = 'open' WHERE id = $1")
                 .bind(dispute_id)
                 .execute(pool)
                 .await
             {
-                tracing::error!("dispute {dispute_id} status reset failed: {e2}");
+                tracing::error!(
+                    %dispute_id,
+                    error = %e2,
+                    "dispute status reset failed",
+                );
             }
         }
     }
     Ok(())
 }
 
+#[tracing::instrument(skip(pool, judge, stellar), fields(%dispute_id, %job_id))]
 async fn process_dispute(
     pool: &PgPool,
     judge: &JudgeService,
@@ -116,9 +126,10 @@ async fn process_dispute(
         .await?;
 
     tracing::info!(
-        "dispute {dispute_id} resolved: winner={} tx={:?}",
-        verdict.winner,
-        on_chain_tx
+        %dispute_id,
+        winner = %verdict.winner,
+        on_chain_tx = ?on_chain_tx,
+        "dispute resolved",
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Adds `json` feature to `tracing-subscriber` so the JSON formatter is available
- `main.rs` now reads `LOG_FORMAT` at startup: set to `json` for machine-readable output (production/CI log aggregators), anything else keeps the default pretty format for local dev
- `worker.rs` log calls converted from interpolated format strings to structured field syntax (`%dispute_id`, `error = %e`, etc.) so every log line carries machine-parseable key-value pairs
- `#[tracing::instrument]` added to `process_dispute`, `LedgerFollower::next_cycle`, and `process_event_side_effects` — each invocation now gets its own span with the relevant IDs automatically recorded in context
- `LOG_FORMAT` documented in `.env.example`

## Test plan

- [ ] `cargo build -p backend` compiles without warnings
- [ ] `cargo test -p backend` passes existing test suite
- [ ] Start with `LOG_FORMAT=json` — log output is newline-delimited JSON
- [ ] Start without `LOG_FORMAT` — log output is human-readable pretty format
- [ ] Trigger a dispute cycle and confirm `dispute_id` / `job_id` appear as structured fields in the span

Closes #203