### PR TITLE
feat: add standalone worker binary and Docker deployment

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "backend"
 path = "src/main.rs"
 
+[[bin]]
+name = "worker"
+path = "src/bin/worker.rs"
+
 [dependencies]
 tokio              = { workspace = true }
 axum               = { workspace = true }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,43 @@
+FROM rust:1.78-slim AS builder
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Cache dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY backend/Cargo.toml backend/Cargo.toml
+COPY contracts/escrow/Cargo.toml contracts/escrow/Cargo.toml
+COPY contracts/reputation/Cargo.toml contracts/reputation/Cargo.toml
+COPY contracts/job_registry/Cargo.toml contracts/job_registry/Cargo.toml
+
+# Dummy sources so cargo can resolve the workspace
+RUN mkdir -p backend/src contracts/escrow/src contracts/reputation/src contracts/job_registry/src && \
+    echo "fn main() {}" > backend/src/main.rs && \
+    echo "" > backend/src/lib.rs && \
+    echo "" > contracts/escrow/src/lib.rs && \
+    echo "" > contracts/reputation/src/lib.rs && \
+    echo "" > contracts/job_registry/src/lib.rs
+
+RUN cargo build --release -p backend 2>/dev/null || true
+
+# Real build
+COPY backend backend
+RUN touch backend/src/main.rs backend/src/lib.rs && \
+    cargo build --release -p backend
+
+# ── API server image ──────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS api
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/backend /usr/local/bin/backend
+COPY backend/migrations /app/migrations
+WORKDIR /app
+CMD ["backend"]
+
+# ── Worker image ──────────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS worker
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/worker /usr/local/bin/worker
+COPY backend/migrations /app/migrations
+WORKDIR /app
+CMD ["worker"]

--- a/backend/src/bin/worker.rs
+++ b/backend/src/bin/worker.rs
@@ -1,0 +1,39 @@
+use sqlx::postgres::PgPoolOptions;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    backend::env_config::load_backend_environment()?;
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "backend=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await?;
+
+    sqlx::migrate!("./migrations").run(&pool).await?;
+
+    tracing::info!("worker process started");
+
+    tokio::select! {
+        _ = backend::indexer::run_indexer_worker(pool.clone()) => {
+            tracing::warn!("indexer worker exited");
+        }
+        _ = backend::worker::run_judge_worker(pool.clone()) => {
+            tracing::warn!("judge worker exited");
+        }
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!("received shutdown signal");
+        }
+    }
+
+    Ok(())
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod db;
+pub mod env_config;
+pub mod error;
+pub mod indexer;
+pub mod indexer_metrics;
+pub mod ledger_follower;
+pub mod middleware;
+pub mod models;
+pub mod routes;
+pub mod services;
+pub mod soroban_rpc;
+pub mod tx_metadata_cache;
+pub mod tx_queue;
+pub mod worker;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,22 +4,8 @@ use std::net::SocketAddr;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-mod db;
-mod env_config;
-mod error;
-mod indexer;
-mod indexer_metrics;
-mod ledger_follower;
-mod middleware;
-mod models;
-mod routes;
-mod services;
-mod soroban_rpc;
-mod tx_metadata_cache;
-mod tx_queue;
-mod worker;
-
-pub use db::AppState;
+use backend::{db, env_config, indexer, middleware, routes, worker};
+use db::AppState;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: lance
+      POSTGRES_PASSWORD: lance
+      POSTGRES_DB: lance
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lance"]
+      interval: 5s
+      retries: 5
+
+  api:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+      target: api
+    env_file: backend/.env
+    environment:
+      DATABASE_URL: postgres://lance:lance@db:5432/lance
+    ports:
+      - "3001:3001"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  worker:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+      target: worker
+    env_file: backend/.env
+    environment:
+      DATABASE_URL: postgres://lance:lance@db:5432/lance
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  pgdata:


### PR DESCRIPTION
- Add backend/src/lib.rs to expose modules as a library crate, allowing the worker binary to share all backend logic without duplication
- Add backend/src/bin/worker.rs: standalone process that runs the Soroban indexer worker and AI judge worker together, with graceful shutdown on SIGINT and auto-migration on startup
- Add backend/Dockerfile: multi-stage build producing two separate images  'api' (Axum HTTP server) and 'worker' (background worker) from a single build context
- Add docker-compose.yml: local dev setup with Postgres, api, and worker as independent services with health-check dependencies

The indexer and judge workers previously ran embedded inside the API server process. This change makes it possible to deploy and scale them independently in Docker/Kubernetes without any changes to the existing API server behaviour.

closes #187 