### PR TITLE
[SC-ESC-011] Partial: checked math + escrow read helpers

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -248,6 +248,20 @@ impl EscrowContract {
         }
     }
 
+    fn checked_add_i128(env: &Env, a: i128, b: i128) -> Result<i128, EscrowError> {
+        a.checked_add(b).ok_or_else(|| {
+            log!(env, "checked_add_i128 overflow: {} + {}", a, b);
+            EscrowError::InvalidInput
+        })
+    }
+
+    fn checked_sub_i128(env: &Env, a: i128, b: i128) -> Result<i128, EscrowError> {
+        a.checked_sub(b).ok_or_else(|| {
+            log!(env, "checked_sub_i128 underflow: {} - {}", a, b);
+            EscrowError::InvalidInput
+        })
+    }
+
     fn sync_dispute_to_job_registry(env: &Env, job_id: u64) -> Result<(), EscrowError> {
         Self::bump_instance_ttl(env);
         let Some(registry_contract) = env
@@ -490,7 +504,8 @@ impl EscrowContract {
 
         let mut total_milestones_amount = 0i128;
         for m in job.milestones.iter() {
-            total_milestones_amount = total_milestones_amount.saturating_add(m.amount);
+            total_milestones_amount =
+                Self::checked_add_i128(&env, total_milestones_amount, m.amount)?;
         }
 
         if total_milestones_amount != amount {
@@ -563,7 +578,8 @@ impl EscrowContract {
         milestone.status = MilestoneStatus::Released;
         job.milestones.set(idx, milestone.clone());
 
-        job.released_amount = job.released_amount.saturating_add(milestone.amount);
+        job.released_amount =
+            Self::checked_add_i128(&env, job.released_amount, milestone.amount)?;
 
         let next_status = if job.released_amount == job.total_amount {
             EscrowStatus::Completed
@@ -790,15 +806,18 @@ impl EscrowContract {
         Self::bump_job_ttl(&env, &key);
         assert!(job.status == EscrowStatus::Disputed, "job not disputed");
 
-        let remaining = job.total_amount - job.released_amount;
-        let total_payout = payee_amount + payer_amount;
+        let remaining = Self::checked_sub_i128(&env, job.total_amount, job.released_amount)
+            .expect("invalid escrow balance state");
+        let total_payout = Self::checked_add_i128(&env, payee_amount, payer_amount)
+            .expect("invalid dispute payout state");
         assert!(total_payout <= remaining, "payout exceeds remaining funds");
 
         let next_status = EscrowStatus::Resolved;
         job.status
             .validate_transition(&next_status)
             .expect("invalid state transition");
-        job.released_amount += total_payout;
+        job.released_amount = Self::checked_add_i128(&env, job.released_amount, total_payout)
+            .expect("released amount overflow");
         job.status = next_status;
 
         enter_reentrancy_guard(&env);
@@ -848,7 +867,7 @@ impl EscrowContract {
             return Err(EscrowError::Unauthorized);
         }
 
-        let remaining = job.total_amount - job.released_amount;
+        let remaining = Self::checked_sub_i128(&env, job.total_amount, job.released_amount)?;
 
         let next_status = EscrowStatus::Refunded;
         job.status.validate_transition(&next_status)?;
@@ -893,6 +912,35 @@ impl EscrowContract {
             statuses.push_back(m.status);
         }
         statuses
+    }
+
+    /// Read-only helper exposing active escrow configuration.
+    pub fn get_escrow_config(env: Env) -> Result<(Address, Address, Option<Address>), EscrowError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(EscrowError::NotInitialized)?;
+        let agent_judge: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::AgentJudge)
+            .ok_or(EscrowError::NotInitialized)?;
+        let job_registry: Option<Address> = env.storage().instance().get(&DataKey::JobRegistry);
+        Self::bump_instance_ttl(&env);
+        Ok((admin, agent_judge, job_registry))
+    }
+
+    /// Read-only helper exposing unreleased escrow balance for a job.
+    pub fn get_remaining_balance(env: Env, job_id: u64) -> Result<i128, EscrowError> {
+        let key = DataKey::Job(job_id);
+        let job: EscrowJob = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(EscrowError::JobNotFound)?;
+        Self::bump_job_ttl(&env, &key);
+        Self::checked_sub_i128(&env, job.total_amount, job.released_amount)
     }
 
     /// Configure multisig for a job. Only callable by client during Setup phase.
@@ -2133,6 +2181,36 @@ mod test {
 
         cc.initialize(&admin, &agent_judge);
         cc.get_job(&999u64);
+    }
+
+    #[test]
+    fn test_getters_for_config_and_remaining_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let agent_judge = Address::generate(&env);
+        let client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_addr = setup_token(&env, &admin);
+        mint(&env, &token_addr, &client);
+
+        let contract_id = env.register_contract(None, EscrowContract);
+        let cc = EscrowContractClient::new(&env, &contract_id);
+
+        cc.initialize(&admin, &agent_judge);
+        cc.create_job(&1u64, &client, &freelancer, &token_addr);
+        cc.add_milestone(&1u64, &4000i128);
+        cc.add_milestone(&1u64, &6000i128);
+        cc.deposit(&1u64, &10000i128);
+        cc.release_milestone(&1u64, &client);
+
+        let (stored_admin, stored_agent, registry) = cc.get_escrow_config().unwrap();
+        assert_eq!(stored_admin, admin);
+        assert_eq!(stored_agent, agent_judge);
+        assert_eq!(registry, None);
+
+        assert_eq!(cc.get_remaining_balance(&1u64).unwrap(), 6000);
     }
 
     #[test]

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2205,12 +2205,12 @@ mod test {
         cc.deposit(&1u64, &10000i128);
         cc.release_milestone(&1u64, &client);
 
-        let (stored_admin, stored_agent, registry) = cc.get_escrow_config().unwrap();
+        let (stored_admin, stored_agent, registry) = cc.get_escrow_config();
         assert_eq!(stored_admin, admin);
         assert_eq!(stored_agent, agent_judge);
         assert_eq!(registry, None);
 
-        assert_eq!(cc.get_remaining_balance(&1u64).unwrap(), 6000);
+        assert_eq!(cc.get_remaining_balance(&1u64), 6000);
     }
 
     #[test]


### PR DESCRIPTION
Closes #365


- replaced selected arithmetic hotspots with checked helpers in deposit/release/refund/dispute resolution paths
- added get_escrow_config() read helper (admin, agent judge, optional registry)
- added get_remaining_balance(job_id) read helper
- added one focused test for getters + remaining balance behavior

- native XLM fee wrapping flow is not fully implemented in this PR
- broader auth/architecture/test expansion deferred to follow-up PRs