### PR TITLE
[SC-ESC-012] Partial: graceful cancel/refund path for briefs

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -38,6 +38,7 @@ impl EscrowStatus {
     pub fn validate_transition(&self, next: &EscrowStatus) -> Result<(), EscrowError> {
         match (self, next) {
             (EscrowStatus::Setup, EscrowStatus::Funded) => Ok(()),
+            (EscrowStatus::Setup, EscrowStatus::Refunded) => Ok(()),
             (EscrowStatus::Funded, EscrowStatus::WorkInProgress) => Ok(()),
             (EscrowStatus::Funded, EscrowStatus::Completed) => Ok(()),
             (EscrowStatus::Funded, EscrowStatus::Disputed) => Ok(()),
@@ -183,6 +184,15 @@ pub struct ContractUpgradedEvent {
     pub by_admin: Address,
     pub new_wasm_hash: BytesN<32>,
     pub upgraded_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct BriefCanceledEvent {
+    pub job_id: u64,
+    pub refunded_amount: i128,
+    pub canceled_by: Address,
+    pub canceled_at: u64,
 }
 
 #[contracttype]
@@ -871,6 +881,64 @@ impl EscrowContract {
         env.events().publish(
             ("escrow", "Refunded"),
             (job_id, client, remaining, env.ledger().timestamp()),
+        );
+
+        Ok(())
+    }
+
+    /// Client cancels a brief and triggers graceful refund behavior.
+    /// Supports Setup (no funds moved yet), Funded, and WorkInProgress states.
+    pub fn cancel_brief(env: Env, job_id: u64, client: Address) -> Result<(), EscrowError> {
+        client.require_auth();
+
+        let key = DataKey::Job(job_id);
+        let mut job: EscrowJob = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(EscrowError::JobNotFound)?;
+        Self::bump_job_ttl(&env, &key);
+
+        if client != job.client {
+            return Err(EscrowError::Unauthorized);
+        }
+
+        if !(job.status == EscrowStatus::Setup
+            || job.status == EscrowStatus::Funded
+            || job.status == EscrowStatus::WorkInProgress)
+        {
+            return Err(EscrowError::InvalidState);
+        }
+
+        let remaining = job
+            .total_amount
+            .checked_sub(job.released_amount)
+            .ok_or(EscrowError::InvalidInput)?;
+
+        let next_status = EscrowStatus::Refunded;
+        job.status.validate_transition(&next_status)?;
+        job.released_amount = job.total_amount;
+        job.status = next_status;
+
+        enter_reentrancy_guard(&env);
+
+        if remaining > 0 {
+            let token_client = token::Client::new(&env, &job.token);
+            token_client.transfer(&env.current_contract_address(), &job.client, &remaining);
+        }
+
+        env.storage().persistent().set(&key, &job);
+        Self::bump_job_ttl(&env, &key);
+        exit_reentrancy_guard(&env);
+
+        env.events().publish(
+            ("escrow", "BriefCanceled"),
+            BriefCanceledEvent {
+                job_id,
+                refunded_amount: remaining,
+                canceled_by: client,
+                canceled_at: env.ledger().timestamp(),
+            },
         );
 
         Ok(())
@@ -2133,6 +2201,29 @@ mod test {
 
         cc.initialize(&admin, &agent_judge);
         cc.get_job(&999u64);
+    }
+
+    #[test]
+    fn test_cancel_brief_in_setup_marks_refunded_without_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let agent_judge = Address::generate(&env);
+        let client = Address::generate(&env);
+        let freelancer = Address::generate(&env);
+        let token_addr = setup_token(&env, &admin);
+
+        let contract_id = env.register_contract(None, EscrowContract);
+        let cc = EscrowContractClient::new(&env, &contract_id);
+
+        cc.initialize(&admin, &agent_judge);
+        cc.create_job(&77u64, &client, &freelancer, &token_addr);
+        cc.cancel_brief(&77u64, &client).unwrap();
+
+        let job = cc.get_job(&77u64);
+        assert_eq!(job.status, EscrowStatus::Refunded);
+        assert_eq!(job.released_amount, 0);
     }
 
     #[test]

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2219,7 +2219,7 @@ mod test {
 
         cc.initialize(&admin, &agent_judge);
         cc.create_job(&77u64, &client, &freelancer, &token_addr);
-        cc.cancel_brief(&77u64, &client).unwrap();
+        cc.cancel_brief(&77u64, &client);
 
         let job = cc.get_job(&77u64);
         assert_eq!(job.status, EscrowStatus::Refunded);


### PR DESCRIPTION
Closes #366


- added cancel_brief(job_id, client) to support graceful cancellation in Setup/Funded/WorkInProgress states
- added BriefCanceled event payload for clear refund auditing
- integrated safe remaining-balance check during cancellation (checked_sub)
- added a focused unit test for setup-state cancellation path
- enabled Setup -> Refunded transition in state validator


- broader refund policy matrix and deadline strategy are not fully implemented in this PR
- deeper multi-path coverage and optimization deferred to follow-up PRs