### PR TITLE
feat(backend): dynamic rate limiting for public intake routes (BE-API-088)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,12 @@ POOL_HEALTH_CHECK_INTERVAL_MS=30000
 POOL_CONNECT_RETRY_LIMIT=3
 POOL_CONNECT_RETRY_BASE_DELAY_MS=500
 
+# Per-IP token bucket on public intake POST routes (auth, job create, bids, uploads, bulk).
+# Effective RPM scales down automatically when the connection pool is busy.
+RATE_LIMIT_RPM=60
+RATE_LIMIT_BURST=10
+RATE_LIMIT_MIN_RPM=15
+
 RUST_LOG=backend=debug,tower_http=debug
 # Set to "json" for structured JSON log output (e.g. in production)
 LOG_FORMAT=pretty

--- a/backend/src/config/db.ts
+++ b/backend/src/config/db.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from "@prisma/client";
 import { Pool, PoolClient } from "pg";
 import { PrismaPg } from "@prisma/adapter-pg";
 import dotenv from "dotenv";
-import { trace, context } from "./tracing";
+import { trace } from "./tracing";
 
 dotenv.config();
 
@@ -188,54 +188,58 @@ export async function connectWithRetry(): Promise<void> {
 // ---------------------------------------------------------------------------
 const adapter = new PrismaPg(pool);
 
-const globalForPrisma = global as unknown as { prisma: PrismaClient };
+const globalForPrisma = global as unknown as { prisma: ReturnType<typeof createPrismaClient> };
 
-// Initialize Prisma with optimized middleware for tracing and performance monitoring
-export const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient({
+function createPrismaClient() {
+  const client = new PrismaClient({
     adapter,
     log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
   });
 
-// Add query middleware for tracing and performance monitoring
-prisma.$use(async (params, next) => {
-  const spanContext = context.active();
-  const startTime = Date.now();
-  const logger = trace.getLogger("db-query");
+  return client.$extends({
+    query: {
+      $allModels: {
+        async $allOperations({ model, operation, args, query }) {
+          const startTime = Date.now();
+          const logger = trace.getLogger("db-query");
 
-  try {
-    const result = await next(params);
-    const duration = Date.now() - startTime;
+          try {
+            const result = await query(args);
+            const duration = Date.now() - startTime;
 
-    // Log slow queries (> 1000ms)
-    if (duration > 1000) {
-      logger.warn(`Slow query detected: ${params.model}.${params.action}`, {
-        duration,
-        model: params.model,
-        action: params.action,
-        args: JSON.stringify(params.args).substring(0, 200),
-      });
-    }
+            if (duration > 1000) {
+              logger.warn(`Slow query detected: ${model}.${operation}`, {
+                duration,
+                model,
+                action: operation,
+                args: JSON.stringify(args).substring(0, 200),
+              });
+            }
 
-    logger.debug(`Query completed: ${params.model}.${params.action}`, {
-      duration,
-      model: params.model,
-      action: params.action,
-    });
+            logger.debug(`Query completed: ${model}.${operation}`, {
+              duration,
+              model,
+              action: operation,
+            });
 
-    return result;
-  } catch (error) {
-    const duration = Date.now() - startTime;
-    logger.error(`Query failed: ${params.model}.${params.action}`, {
-      duration,
-      model: params.model,
-      action: params.action,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  }
-});
+            return result;
+          } catch (error) {
+            const duration = Date.now() - startTime;
+            logger.error(`Query failed: ${model}.${operation}`, {
+              duration,
+              model,
+              action: operation,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            throw error;
+          }
+        },
+      },
+    },
+  });
+}
+
+export const prisma = globalForPrisma.prisma || createPrismaClient();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,8 @@ import express, { Express, Request, Response } from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import { prisma, connectWithRetry, startPoolHealthCheck } from "./config/db";
+import { trace } from "./config/tracing";
+import { intakeRateLimit } from "./middleware/intakeRateLimit";
 import { tracingMiddleware } from "./utils/tracing";
 import authRoutes from "./routes/auth";
 import jobsRoutes from "./routes/jobs";
@@ -23,6 +25,7 @@ const logger = trace.getLogger("server");
 app.use(cors({ origin: "*" }));
 app.use(express.json());
 app.use(tracingMiddleware); // Global request tracing and diagnostics
+app.use(intakeRateLimit);
 
 // Request logging middleware with tracing
 app.use((req: Request, res: Response, next) => {

--- a/backend/src/middleware/intakeRateLimit.ts
+++ b/backend/src/middleware/intakeRateLimit.ts
@@ -1,0 +1,127 @@
+import { Request, Response, NextFunction } from "express";
+import { getPoolHealthStats } from "../config/db";
+import { logger } from "../utils/tracing";
+
+interface Bucket {
+  tokens: number;
+  lastMs: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+function envInt(key: string, fallback: number): number {
+  const v = process.env[key];
+  if (!v) return fallback;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Shrink the per-minute quota when the pg pool is under pressure. */
+export function effectiveRpm(): number {
+  const base = envInt("RATE_LIMIT_RPM", 60);
+  const floor = envInt("RATE_LIMIT_MIN_RPM", 15);
+  const stats = getPoolHealthStats();
+  const max = Math.max(stats.maxConnections, 1);
+  const activeRatio = stats.activeConnections / max;
+  const waitPenalty = stats.waitingRequests > 0 ? 0.35 + Math.min(0.35, stats.waitingRequests / 8) : 0;
+  const pressure = Math.min(0.85, activeRatio * 0.45 + waitPenalty);
+  return Math.max(floor, Math.floor(base * (1 - pressure)));
+}
+
+function burstCap(rpm: number): number {
+  const burst = envInt("RATE_LIMIT_BURST", 10);
+  return rpm + burst;
+}
+
+function takeToken(key: string): { ok: true } | { ok: false; retryAfter: number } {
+  const rpm = effectiveRpm();
+  const cap = burstCap(rpm);
+  const refillPerMs = rpm / 60_000;
+  const now = Date.now();
+
+  let bucket = buckets.get(key);
+  if (!bucket) {
+    bucket = { tokens: cap, lastMs: now };
+    buckets.set(key, bucket);
+  }
+
+  const elapsed = now - bucket.lastMs;
+  bucket.tokens = Math.min(cap, bucket.tokens + elapsed * refillPerMs);
+  bucket.lastMs = now;
+
+  if (bucket.tokens < 1) {
+    const retryAfter = Math.max(1, Math.ceil((1 - bucket.tokens) / refillPerMs / 1000));
+    return { ok: false, retryAfter };
+  }
+
+  bucket.tokens -= 1;
+  return { ok: true };
+}
+
+export function clientIp(req: Request): string {
+  const forwarded = req.headers["x-forwarded-for"];
+  if (typeof forwarded === "string" && forwarded.length > 0) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return req.ip || req.socket.remoteAddress || "127.0.0.1";
+}
+
+/** Unauthenticated write paths that accept external submissions. */
+export function isPublicIntakeRoute(req: Request): boolean {
+  if (req.method !== "POST") return false;
+  const path = req.originalUrl.split("?")[0] ?? req.path;
+
+  if (path.startsWith("/api/v1/auth")) return true;
+  if (path === "/api/v1/jobs" || path === "/api/v1/jobs/") return true;
+  if (/^\/api\/v1\/jobs\/[^/]+\/bids\/?$/.test(path)) return true;
+  if (path.startsWith("/api/v1/uploads")) return true;
+  if (path.startsWith("/api/v1/bulk")) return true;
+
+  return false;
+}
+
+export function intakeRateLimit(req: Request, res: Response, next: NextFunction): void {
+  if (!isPublicIntakeRoute(req)) {
+    next();
+    return;
+  }
+
+  const key = clientIp(req);
+  const result = takeToken(key);
+
+  if (result.ok) {
+    next();
+    return;
+  }
+
+  const rpm = effectiveRpm();
+  logger.warn("Public intake rate limit exceeded", {
+    ip: key,
+    path: req.originalUrl,
+    retryAfterSeconds: result.retryAfter,
+    effectiveRpm: rpm,
+  });
+
+  res.setHeader("Retry-After", String(result.retryAfter));
+  res.status(429).json({
+    error: "rate limit exceeded",
+    retry_after_seconds: result.retryAfter,
+  });
+}
+
+// Drop idle buckets so long-running processes do not grow memory without bound.
+const pruneMs = 10 * 60 * 1000;
+const pruneTimer = setInterval(() => {
+  const cutoff = Date.now() - pruneMs;
+  for (const [key, bucket] of buckets) {
+    if (bucket.lastMs < cutoff) buckets.delete(key);
+  }
+}, 60_000);
+if (typeof pruneTimer === "object" && "unref" in pruneTimer) {
+  pruneTimer.unref();
+}
+
+export function intakeBucketCount(): number {
+  return buckets.size;
+}

--- a/backend/src/routes/pool.ts
+++ b/backend/src/routes/pool.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { pool, getPoolHealthStats } from "../config/db";
+import { effectiveRpm, intakeBucketCount } from "../middleware/intakeRateLimit";
 import { logger } from "../utils/tracing";
 
 const router = Router();
@@ -114,6 +115,10 @@ router.get("/stats", async (req: Request, res: Response) => {
       uptimeSeconds: stats.uptimeSeconds,
       healthChecksPassed: stats.healthChecksPassed,
       healthChecksFailed: stats.healthChecksFailed,
+      intakeRateLimit: {
+        effectiveRpm: effectiveRpm(),
+        trackedClients: intakeBucketCount(),
+      },
     });
   } catch (error: any) {
     logger.error("Pool stats endpoint error", { error: error.message });


### PR DESCRIPTION
Closes #442

---

## Summary

- Adds per-IP token-bucket rate limiting on public intake POST routes (`/auth`, job create, bids, uploads, bulk`).
- Scales effective RPM down automatically when the PostgreSQL connection pool is under pressure.
- Exposes `intakeRateLimit` stats on `GET /api/v1/pool/stats` for observability.
- Fixes backend CI build by replacing removed Prisma 7 `$use` middleware with a `$extends` query hook.

## Test plan

- [x] `npm run build --prefix backend` (with `npx prisma generate`)
- [ ] `curl` burst against `POST /api/v1/auth/challenge` → expect `429` after limit
- [ ] `GET /api/v1/pool/stats` → verify `intakeRateLimit.effectiveRpm` under load


