### PR TITLE
feat(be-w3a-115): configure secure cookie storage for session JWTs

### DIFF
--- a/apps/web/hooks/use-wallet.ts
+++ b/apps/web/hooks/use-wallet.ts
@@ -54,13 +54,13 @@ export function useWallet() {
       const signature = await kit.signMessage(challenge);
 
       // 4. Verify signature on backend
-      const { token } = await api.auth.verify(address, signature);
+      const { access_token } = await api.auth.verify(address, signature);
 
-      // 5. Update store
+      // 5. Update store (token is now in cookie, but keep in store for compatibility)
       login(
         {
           address,
-          token,
+          token: access_token,
           name: address.slice(0, 4) + "..." + address.slice(-4),
           email: "",
         },

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -5,12 +5,10 @@ import { useAuthStore } from "./store/use-auth-store";
 import type { ReputationMetrics } from "./reputation";
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const token = useAuthStore.getState().user?.token;
-  
   const res = await fetch(`${API}/api${path}`, {
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      ...(token ? { "Authorization": `Bearer ${token}` } : {}),
       ...(init?.headers ?? {}),
     },
     ...init,
@@ -248,9 +246,10 @@ export interface AuthChallengeResponse {
 }
 
 export interface AuthVerifyResponse {
-  token: string;
-  expires_at: string;
-  user_address: string;
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  expires_in: number;
 }
 
 export interface MetadataUploadResponse {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@stellar/stellar-sdk": "^15.1.0",
         "bullmq": "^5.77.3",
         "compression": "^1.8.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
@@ -27,6 +28,7 @@
       },
       "devDependencies": {
         "@types/compression": "^1.8.1",
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
@@ -744,6 +746,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -1492,6 +1504,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "@stellar/stellar-sdk": "^15.1.0",
     "bullmq": "^5.77.3",
     "compression": "^1.8.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@types/compression": "^1.8.1",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,6 @@
 import express, { Express, Request, Response } from "express";
 import cors from "cors";
+import cookieParser from "cookie-parser";
 import dotenv from "dotenv";
 import { prisma, connectWithRetry, startPoolHealthCheck } from "./config/db";
 import { trace } from "./config/tracing";
@@ -26,8 +27,13 @@ const app: Express = express();
 const port = process.env.PORT || 3001;
 const logger = trace.getLogger("server");
 
-// Enable CORS for frontend requests
-app.use(cors({ origin: "*" }));
+// Enable CORS for frontend requests with credentials support
+const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
+app.use(cors({
+  origin: FRONTEND_URL,
+  credentials: true,
+}));
+app.use(cookieParser());
 app.use(express.json());
 app.use(tracingMiddleware); // Global request tracing and diagnostics
 app.use(intakeRateLimit);

--- a/backend/src/middleware/authGuard.ts
+++ b/backend/src/middleware/authGuard.ts
@@ -30,19 +30,25 @@ export interface AuthRequest extends Request {
   auth?: JwtPayload & { address: string; jti: string };
 }
 
+const ACCESS_TOKEN_COOKIE = "lance_access_token";
+
 export async function authGuard(
   req: AuthRequest,
   res: Response,
   next: NextFunction
 ): Promise<void> {
+  // Try to get token from cookie first, then from Authorization header
+  let token = req.cookies[ACCESS_TOKEN_COOKIE];
   const header = req.headers.authorization;
+  if (!token && header?.startsWith("Bearer ")) {
+    token = header.slice(7);
+  }
 
-  if (!header?.startsWith("Bearer ")) {
-    res.status(401).json({ error: "Authorization header missing or malformed" });
+  if (!token) {
+    res.status(401).json({ error: "Authorization token missing or malformed" });
     return;
   }
 
-  const token  = header.slice(7);
   const secret = process.env.JWT_SECRET;
 
   if (!secret) {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -28,6 +28,17 @@ import { Keypair } from "@stellar/stellar-sdk";
 import { prisma } from "../config/db";
 import { redis } from "../config/redis";
 
+// Cookie configuration constants
+const isProduction = process.env.NODE_ENV === "production";
+const ACCESS_TOKEN_COOKIE = "lance_access_token";
+const REFRESH_TOKEN_COOKIE = "lance_refresh_token";
+const COOKIE_BASE_OPTIONS = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: isProduction ? "strict" : "lax",
+  path: "/",
+} as const;
+
 const router = Router();
 
 // ---------------------------------------------------------------------------
@@ -323,6 +334,16 @@ router.post(
       const accessToken = issueAccessToken(address, accessJti);
       const { rawToken: refreshToken } = await issueRefreshToken(address);
 
+      // Set secure cookies
+      res.cookie(ACCESS_TOKEN_COOKIE, accessToken, {
+        ...COOKIE_BASE_OPTIONS,
+        maxAge: ACCESS_TOKEN_TTL_SEC * 1000,
+      });
+      res.cookie(REFRESH_TOKEN_COOKIE, refreshToken, {
+        ...COOKIE_BASE_OPTIONS,
+        maxAge: REFRESH_TOKEN_TTL_SEC * 1000,
+      });
+
       return res.status(200).json({
         access_token: accessToken,
         refresh_token: refreshToken,
@@ -347,23 +368,26 @@ router.post(
 // ---------------------------------------------------------------------------
 
 interface RefreshBody {
-  refresh_token: string;
+  refresh_token?: string;
 }
 
 router.post(
   "/refresh",
   async (req: Request<{}, {}, RefreshBody>, res: Response) => {
     try {
-      const { refresh_token } = req.body;
+      let refreshToken = req.body.refresh_token;
+      if (!refreshToken) {
+        refreshToken = req.cookies[REFRESH_TOKEN_COOKIE];
+      }
 
-      if (!refresh_token || typeof refresh_token !== "string") {
+      if (!refreshToken || typeof refreshToken !== "string") {
         return res.status(400).json({ error: "refresh_token is required" });
       }
 
       // Hash the incoming token and look it up — never store/compare raw.
       const incomingHash = crypto
         .createHash("sha256")
-        .update(refresh_token)
+        .update(refreshToken)
         .digest("hex");
 
       const record = await prisma.refresh_tokens.findUnique({
@@ -395,6 +419,16 @@ router.post(
         record.id           // Marks this record as revoked inside issueRefreshToken
       );
 
+      // Set secure cookies
+      res.cookie(ACCESS_TOKEN_COOKIE, newAccessToken, {
+        ...COOKIE_BASE_OPTIONS,
+        maxAge: ACCESS_TOKEN_TTL_SEC * 1000,
+      });
+      res.cookie(REFRESH_TOKEN_COOKIE, newRefreshToken, {
+        ...COOKIE_BASE_OPTIONS,
+        maxAge: REFRESH_TOKEN_TTL_SEC * 1000,
+      });
+
       return res.status(200).json({
         access_token: newAccessToken,
         refresh_token: newRefreshToken,
@@ -416,52 +450,65 @@ router.post(
 // ---------------------------------------------------------------------------
 
 router.post("/logout", async (req: Request, res: Response) => {
-  try {
-    const authHeader = req.headers.authorization;
-    const { refresh_token } = req.body as { refresh_token?: string };
+    try {
+      // Try to get access token from cookie first, then header
+      let rawAccessToken = req.cookies[ACCESS_TOKEN_COOKIE];
+      const authHeader = req.headers.authorization;
+      if (!rawAccessToken && authHeader?.startsWith("Bearer ")) {
+        rawAccessToken = authHeader.slice(7);
+      }
+      // Try to get refresh token from cookie first, then body
+      let refreshToken = req.cookies[REFRESH_TOKEN_COOKIE];
+      const { refresh_token } = req.body as { refresh_token?: string };
+      if (!refreshToken && refresh_token) {
+        refreshToken = refresh_token;
+      }
 
-    // ── Blacklist the access token ─────────────────────────────────────────
-    if (authHeader?.startsWith("Bearer ")) {
-      const rawAccessToken = authHeader.slice(7);
-      const secret = process.env.JWT_SECRET;
+      // ── Blacklist the access token ─────────────────────────────────────
+      if (rawAccessToken) {
+        const secret = process.env.JWT_SECRET;
 
-      if (secret) {
-        try {
-          const decoded = jwt.verify(rawAccessToken, secret, {
-            issuer: "lance-marketplace",
-            audience: "lance-frontend",
-          }) as JwtPayload;
+        if (secret) {
+          try {
+            const decoded = jwt.verify(rawAccessToken, secret, {
+              issuer: "lance-marketplace",
+              audience: "lance-frontend",
+            }) as JwtPayload;
 
-          if (decoded.jti && decoded.exp) {
-            await blacklistToken(decoded.jti, decoded.exp);
+            if (decoded.jti && decoded.exp) {
+              await blacklistToken(decoded.jti, decoded.exp);
+            }
+          } catch {
+            // Expired / malformed tokens are silently ignored — we're logging out.
           }
-        } catch {
-          // Expired / malformed tokens are silently ignored — we're logging out.
         }
       }
+
+      // ── Revoke the refresh token ───────────────────────────────────────
+      if (refreshToken && typeof refreshToken === "string") {
+        const hash = crypto
+          .createHash("sha256")
+          .update(refreshToken)
+          .digest("hex");
+
+        await prisma.refresh_tokens
+          .updateMany({
+            where: { token_hash: hash, revoked: false },
+            data: { revoked: true },
+          })
+          .catch(() => {}); // Best-effort; missing record is not an error.
+      }
+
+      // Clear cookies
+      res.clearCookie(ACCESS_TOKEN_COOKIE, COOKIE_BASE_OPTIONS);
+      res.clearCookie(REFRESH_TOKEN_COOKIE, COOKIE_BASE_OPTIONS);
+
+      return res.status(200).json({ message: "Logged out successfully" });
+    } catch (error) {
+      console.error("[auth/logout] Unexpected error:", error);
+      return res.status(500).json({ error: "Internal server error" });
     }
-
-    // ── Revoke the refresh token ───────────────────────────────────────────
-    if (refresh_token && typeof refresh_token === "string") {
-      const hash = crypto
-        .createHash("sha256")
-        .update(refresh_token)
-        .digest("hex");
-
-      await prisma.refresh_tokens
-        .updateMany({
-          where: { token_hash: hash, revoked: false },
-          data: { revoked: true },
-        })
-        .catch(() => {}); // Best-effort; missing record is not an error.
-    }
-
-    return res.status(200).json({ message: "Logged out successfully" });
-  } catch (error) {
-    console.error("[auth/logout] Unexpected error:", error);
-    return res.status(500).json({ error: "Internal server error" });
-  }
-});
+  });
 
 // ---------------------------------------------------------------------------
 // Utility exports — consumed by auth middleware in other routes


### PR DESCRIPTION
## Description
Implements secure cookie storage for session JWTs as specified in BE-W3A-115.

## Changes
- Added `cookie-parser` dependency
- Configured CORS with credentials support
- Updated auth routes to set secure HttpOnly cookies for access and refresh tokens
- Updated auth guard to read access token from cookie (with fallback to Authorization header for backward compatibility)
- Updated frontend API client to use `credentials: "include"`
- Updated logout route to clear cookies

## Security
- HttpOnly cookies prevent XSS attacks
- Secure cookies (in production) prevent MITM attacks
- SameSite cookies prevent CSRF attacks
- Backward compatibility maintained with existing Authorization header approach
- 

closes #469 